### PR TITLE
Added temporary workaround for Playstate time

### DIFF
--- a/source/GameActivity.cs
+++ b/source/GameActivity.cs
@@ -1113,7 +1113,7 @@ namespace GameActivity
         {
             // PlayState will write the Id and pausedTime to PlayState.txt file placed inside ExtensionsData Roaming Playnite folder
             // Check first if this file exists and if not return false to avoid executing unnecessary code.
-            string PlayStateFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Playnite", "ExtensionsData", "PlayState.txt");
+            string PlayStateFile = Path.Combine(PlayniteApi.Paths.ExtensionsDataPath, "PlayState.txt");
             if (File.Exists(PlayStateFile))
             {
                 return true;
@@ -1129,7 +1129,7 @@ namespace GameActivity
             // PlayState will write the Id and pausedTime to PlayState.txt file placed inside ExtensionsData Roaming Playnite folder
             // Check first if this file exists and if not return 0 as pausedTime.
             // This check is redundant with ExistsPlayStateInfoFile, but it's because the PlayState file will be modified after the first check, so added as a fallback to avoid exceptions.
-            string PlayStateFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Playnite", "ExtensionsData", "PlayState.txt");
+            string PlayStateFile = Path.Combine(PlayniteApi.Paths.ExtensionsDataPath, "PlayState.txt");
             if (!File.Exists(PlayStateFile))
             {
                 return 0;
@@ -1143,7 +1143,7 @@ namespace GameActivity
             // After retrieving the info restart the file in order to avoid reusing the same txt if PlayState crash / gets uninstalled.
             string[] info = { " ", " " };
 
-            File.WriteAllLines(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Playnite", "ExtensionsData", "PlayState.txt"), info);
+            File.WriteAllLines(PlayStateFile, info);
 
             // Check that the GameId is the same as the paused game. If so, return the paused time. If not, return 0.
             if (game.Id.ToString() == Id)

--- a/source/GameActivity.cs
+++ b/source/GameActivity.cs
@@ -1068,13 +1068,25 @@ namespace GameActivity
                     if (ElapsedSeconds == 0)
                     {
                         Thread.Sleep(5000);
-                        ElapsedSeconds = args.Game.Playtime - PlaytimeOnStarted;
+                        if (ExistsPlayStateInfoFile()) // Temporary workaround for PlayState paused time until Playnite allows to share data among extensions
+                        {
+                            ElapsedSeconds = args.Game.Playtime - PlaytimeOnStarted - GetPlayStatePausedTimeInfo(args.Game);
+                        }
+                        else
+                        {
+                            ElapsedSeconds = args.Game.Playtime - PlaytimeOnStarted;
+                        }
 
                         PlayniteApi.Notifications.Add(new NotificationMessage(
                             $"gameactivity-noElapsedSeconds",
                             $"GameActivity" + System.Environment.NewLine + string.Format(resources.GetString("LOCGameActivityNoPlaytime"), args.Game.Name, ElapsedSeconds),
                             NotificationType.Info
                         ));
+                    }
+                    else if (ExistsPlayStateInfoFile()) // Temporary workaround for PlayState paused time until Playnite allows to share data among extensions
+                    {
+                        Thread.Sleep(5000); // Necessary since PlayState is executed after GameActivity.
+                        ElapsedSeconds -= GetPlayStatePausedTimeInfo(args.Game);
                     }
 
                     // Infos
@@ -1095,6 +1107,53 @@ namespace GameActivity
             // Delete backup
             string PathFileBackup = Path.Combine(PluginDatabase.Paths.PluginUserDataPath, "SaveSession.json");
             FileSystem.DeleteFile(PathFileBackup);
+        }
+
+        private bool ExistsPlayStateInfoFile()
+        {
+            // PlayState will write the Id and pausedTime to PlayState.txt file placed inside ExtensionsData Roaming Playnite folder
+            // Check first if this file exists and if not return false to avoid executing unnecessary code.
+            string PlayStateFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Playnite", "ExtensionsData", "PlayState.txt");
+            if (File.Exists(PlayStateFile))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        private ulong GetPlayStatePausedTimeInfo(Game game) // Temporary workaround for PlayState paused time until Playnite allows to share data among extensions
+        {
+            // PlayState will write the Id and pausedTime to PlayState.txt file placed inside ExtensionsData Roaming Playnite folder
+            // Check first if this file exists and if not return 0 as pausedTime.
+            // This check is redundant with ExistsPlayStateInfoFile, but it's because the PlayState file will be modified after the first check, so added as a fallback to avoid exceptions.
+            string PlayStateFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Playnite", "ExtensionsData", "PlayState.txt");
+            if (!File.Exists(PlayStateFile))
+            {
+                return 0;
+            }
+
+            // The file is a simple txt, first line is GameId and second line the paused time.
+            string[] PlayStateInfo = File.ReadAllLines(PlayStateFile);
+            string Id = PlayStateInfo[0];
+            ulong PausedSeconds = Convert.ToUInt64(PlayStateInfo[1]);
+
+            // After retrieving the info restart the file in order to avoid reusing the same txt if PlayState crash / gets uninstalled.
+            string[] info = { " ", " " };
+
+            File.WriteAllLines(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Playnite", "ExtensionsData", "PlayState.txt"), info);
+
+            // Check that the GameId is the same as the paused game. If so, return the paused time. If not, return 0.
+            if (game.Id.ToString() == Id)
+            {
+                return PausedSeconds;
+            }
+            else
+            {
+                return 0;
+            }
         }
         #endregion
 

--- a/source/GameActivity.cs
+++ b/source/GameActivity.cs
@@ -1109,7 +1109,7 @@ namespace GameActivity
             FileSystem.DeleteFile(PathFileBackup);
         }
 
-        private bool ExistsPlayStateInfoFile()
+        private bool ExistsPlayStateInfoFile() // Temporary workaround for PlayState paused time until Playnite allows to share data among extensions
         {
             // PlayState will write the Id and pausedTime to PlayState.txt file placed inside ExtensionsData Roaming Playnite folder
             // Check first if this file exists and if not return false to avoid executing unnecessary code.
@@ -1141,9 +1141,9 @@ namespace GameActivity
             ulong PausedSeconds = Convert.ToUInt64(PlayStateInfo[1]);
 
             // After retrieving the info restart the file in order to avoid reusing the same txt if PlayState crash / gets uninstalled.
-            string[] info = { " ", " " };
+            string[] Info = { " ", " " };
 
-            File.WriteAllLines(PlayStateFile, info);
+            File.WriteAllLines(PlayStateFile, Info);
 
             // Check that the GameId is the same as the paused game. If so, return the paused time. If not, return 0.
             if (game.Id.ToString() == Id)


### PR DESCRIPTION
This PR is linked to this PR of PlayState extension: https://github.com/darklinkpower/PlayniteExtensionsCollection/pull/193

Temporary workaround for #55 

I used the simple code as possible since this is only a temporary workaround until Playnite allows to share data among extensions.

The PlayState file is placed inside AppData/Roaming/Playnite/ExtensionsData folder with the name of "PlayState.txt". This file will be cleaned after executing one game or retrieving the info on GameActivity plugin in order to avoid reusing the same information over and over again if PlayState gets uninstalled or is not working for any reason.

I added as much code as possible in new methods, notes for explaining the functioning and a annotation that says:

> // Temporary workaround for sharing PlayState paused time until Playnite allows to share data among extensions

in order to ease the removal in the future when another better method is available.