### PR TITLE
Added a setting for disabling PlayState.txt reading

### DIFF
--- a/source/GameActivity.cs
+++ b/source/GameActivity.cs
@@ -1112,7 +1112,7 @@ namespace GameActivity
                     if (ElapsedSeconds == 0)
                     {
                         Thread.Sleep(5000);
-                        if (ExistsPlayStateInfoFile()) // Temporary workaround for PlayState paused time until Playnite allows to share data among extensions
+                        if (ExistsPlayStateInfoFile() && PluginSettings.Settings.SubstPlayStateTime) // Temporary workaround for PlayState paused time until Playnite allows to share data among extensions
                         {
                             ElapsedSeconds = args.Game.Playtime - runningActivity.PlaytimeOnStarted - GetPlayStatePausedTimeInfo(args.Game);
                         }
@@ -1127,7 +1127,7 @@ namespace GameActivity
                             NotificationType.Info
                         ));
                     }
-                    else if (ExistsPlayStateInfoFile()) // Temporary workaround for PlayState paused time until Playnite allows to share data among extensions
+                    else if (ExistsPlayStateInfoFile() && PluginSettings.Settings.SubstPlayStateTime) // Temporary workaround for PlayState paused time until Playnite allows to share data among extensions
                     {
                         Thread.Sleep(10000); // Necessary since PlayState is executed after GameActivity.
                         ElapsedSeconds -= GetPlayStatePausedTimeInfo(args.Game);

--- a/source/GameActivity.cs
+++ b/source/GameActivity.cs
@@ -1112,7 +1112,7 @@ namespace GameActivity
                     if (ElapsedSeconds == 0)
                     {
                         Thread.Sleep(5000);
-                        if (ExistsPlayStateInfoFile() && PluginSettings.Settings.SubstPlayStateTime) // Temporary workaround for PlayState paused time until Playnite allows to share data among extensions
+                        if (PluginSettings.Settings.SubstPlayStateTime && ExistsPlayStateInfoFile()) // Temporary workaround for PlayState paused time until Playnite allows to share data among extensions
                         {
                             ElapsedSeconds = args.Game.Playtime - runningActivity.PlaytimeOnStarted - GetPlayStatePausedTimeInfo(args.Game);
                         }
@@ -1127,7 +1127,7 @@ namespace GameActivity
                             NotificationType.Info
                         ));
                     }
-                    else if (ExistsPlayStateInfoFile() && PluginSettings.Settings.SubstPlayStateTime) // Temporary workaround for PlayState paused time until Playnite allows to share data among extensions
+                    else if (PluginSettings.Settings.SubstPlayStateTime && ExistsPlayStateInfoFile()) // Temporary workaround for PlayState paused time until Playnite allows to share data among extensions
                     {
                         Thread.Sleep(10000); // Necessary since PlayState is executed after GameActivity.
                         ElapsedSeconds -= GetPlayStatePausedTimeInfo(args.Game);

--- a/source/GameActivitySettings.cs
+++ b/source/GameActivitySettings.cs
@@ -91,6 +91,8 @@ namespace GameActivity
         public bool CumulPlaytimeSession { get; set; } = false;
         public bool CumulPlaytimeStore { get; set; } = false;
 
+        public bool SubstPlayStateTime { get; set; } = false; // Temporary workaround for PlayState paused time until Playnite allows to share data among extensions
+
         public List<StoreColor> StoreColors { get; set; } = new List<StoreColor>();
 
         public bool EnableLogging { get; set; } = false;

--- a/source/Localization/en_US.xaml
+++ b/source/Localization/en_US.xaml
@@ -153,4 +153,7 @@ Click for more information.</sys:String>
     <sys:String x:Key="LOCGaDateStart">Date start</sys:String>
     <sys:String x:Key="LOCGaDateEnd">Date end</sys:String>
 
+    <!-- Temporary workaround for PlayState paused time until Playnite allows to share data among extensions -->
+    <sys:String x:Key="LOCGameActivitySubstPlayStateTime">Substract PlayState pause time from the session duration</sys:String>
+
 </ResourceDictionary>

--- a/source/Views/GameActivitySettingsView.xaml
+++ b/source/Views/GameActivitySettingsView.xaml
@@ -51,6 +51,11 @@
                             <Label Content="{DynamicResource LOCGameActivityCumulPlaytimeStore}" />
                         </CheckBox>
 
+                        <!-- Temporary workaround for PlayState paused time until Playnite allows to share data among extensions -->
+                        <CheckBox IsChecked="{Binding Settings.SubstPlayStateTime}" Margin="0,15,0,0">
+                            <Label Content="{DynamicResource LOCGameActivitySubstPlayStateTime}" />
+                        </CheckBox>
+
                         <Label Margin="0,15,0,0" Content="{DynamicResource LOCGameActivityListGamesFields}" />
                         <Grid Margin="30,0,0,0">
                             <Grid.ColumnDefinitions>

--- a/source/Views/GameActivityViewSingle.xaml.cs
+++ b/source/Views/GameActivityViewSingle.xaml.cs
@@ -345,7 +345,7 @@ namespace GameActivity.Views
                         if ((long)(game.Playtime - activity.GameElapsedSeconds) >= 0)
                         {
                             game.Playtime -= activity.GameElapsedSeconds;
-                            if (game.PlayCount > 1)
+                            if (game.PlayCount > 0)
                             {
                                 game.PlayCount--;
                             }


### PR DESCRIPTION
Also added the option to set to 0 the PlayTime count on #132 . Currently when the Playtime count was 1 nothing happens when removing an entry.

I didn't add the setting in the first play to avoid adding more code to be removed on the future, but I think that even in the future this setting could be useful when a proper way is added. In any case I added the same comment on all places as on the other PR to ease the localization of all code related to this feature.

I tested all the scenarios I can think of and didn't found any issue. I hope there isn't more unpleasant surprises in the future about this.