### PR TITLE
Fix already in use error caused by faulty usage of => operator

### DIFF
--- a/source/Controls/TimePicker/TimePicker.xaml.cs
+++ b/source/Controls/TimePicker/TimePicker.xaml.cs
@@ -15,7 +15,7 @@ namespace TemperatureMeasurementTool
     /// </summary>
     public partial class TimePicker : UserControl
     {
-        public static RoutedEvent TimeChangedEvent => EventManager.RegisterRoutedEvent("TimeChanged", RoutingStrategy.Direct, typeof(RoutedEventHandler), typeof(TimePicker));
+        public static readonly RoutedEvent TimeChangedEvent = EventManager.RegisterRoutedEvent("TimeChanged", RoutingStrategy.Direct, typeof(RoutedEventHandler), typeof(TimePicker));
 
         public event RoutedEventHandler TimeChanged
         {


### PR DESCRIPTION
Using the `=>` operator for the event binding results in the application trying to bind the event more than once causing a `System.ArgumentException` depicting that the RoutedEvent name `TimeChanged` is already in use.

This error prevents the usage of all windows using the TimePicker.

Partial revert of: ebbf991844066bbcdc25ef3511e6f863876d7e64